### PR TITLE
Zjednodušení vícesloupcového CSS

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,20 +1,9 @@
 .movie-list {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 10px;
   flex-wrap: wrap;
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-@media (max-width: 1000px) {
-  .movie-list {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-@media (max-width: 600px) {
-  .movie-list {
-    grid-template-columns: 1fr;
-  }
 }


### PR DESCRIPTION
Původní kód používal media queries v kontradikci s tím, že učíme mobile first přístup.

V prvním commitu jsem přepsal media queries na `min-width` a v druhém se jich zbavil úplně, protože si grid umí poradit elegantněji i bez nich.